### PR TITLE
MODDATAIMP-403 - Fixed record type determination by leader

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-## 1.8.0-SNAPSHOT 2021-02-05
+## 1.8.1-SNAPSHOT 2021-02-05
+* [MODDATAIMP-403](https://issues.folio.org/browse/MODDATAIMP-403) Fixed record type determination by leader
+
+## 1.8.0 2021-02-05
 * [MODDATAIMP-365](https://issues.folio.org/browse/MODDATAIMP-365) Upgrade data-import-utils to RAML Module Builder 32.x
 
 ## 1.7.0 2021-01-12

--- a/src/main/java/org/folio/dataimport/util/marc/MarcRecordAnalyzer.java
+++ b/src/main/java/org/folio/dataimport/util/marc/MarcRecordAnalyzer.java
@@ -14,7 +14,7 @@ import static java.util.Arrays.asList;
 public class MarcRecordAnalyzer implements RecordAnalyzer {
   private static final Logger LOGGER = LogManager.getLogger();
   private static final String LEADER_KEY = "leader";
-  private static final int RECORD_TYPE_INDEX = 5;
+  private static final int RECORD_TYPE_INDEX = 6;
   private static final Set<Character> BIB_CODES = new HashSet<>(asList('a', 'c', 'd', 'e', 'f', 'g', 'i', 'j', 'k', 'm', 'o', 'p', 'r', 't'));
   private static final Set<Character> HOLDING_CODES = new HashSet<>(asList('u', 'v', 'x', 'y'));
   private static final Set<Character> AUTHORITY_CODES = new HashSet<>(Collections.singletonList('z'));

--- a/src/test/java/org/folio/dataimport/util/marc/MarcRecordAnalyzerTest.java
+++ b/src/test/java/org/folio/dataimport/util/marc/MarcRecordAnalyzerTest.java
@@ -18,14 +18,14 @@ public class MarcRecordAnalyzerTest {
 
   @Test
   public void process_Holding_OK() {
-    JsonObject record = new JsonObject("{\"leader\":\"13112uam a2200553Ii 4500\"}");
+    JsonObject record = new JsonObject("{\"leader\":\"13112cum a2200553Ii 4500\"}");
     MarcRecordType result = analyzer.process(record);
     assertEquals(MarcRecordType.HOLDING, result);
   }
 
   @Test
   public void process_Authority_OK() {
-    JsonObject record = new JsonObject("{\"leader\":\"13112zam a2200553Ii 4500\"}");
+    JsonObject record = new JsonObject("{\"leader\":\"13112czm a2200553Ii 4500\"}");
     MarcRecordType result = analyzer.process(record);
     assertEquals(MarcRecordType.AUTHORITY, result);
   }


### PR DESCRIPTION
fixed record type determination by leader

## Learning
[MODDATAIMP-403](https://issues.folio.org/browse/MODDATAIMP-403)
https://www.loc.gov/marc/bibliographic/bdleader.html
https://www.loc.gov/marc/bibliographic/examples.html