### PR TITLE
MODDATAIMP-665: Update dependencies (RMB, ...) (CVE-2021-44228)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.0.0</vertx.version>
-    <mod-configuration-client.version>5.6.0</mod-configuration-client.version>
-    <raml-module-builder.version>32.1.0</raml-module-builder.version>
-    <junit.version>4.13</junit.version>
-    <powermock.version>1.7.1</powermock.version>
+    <vertx.version>4.2.6</vertx.version>
+    <mod-configuration-client.version>5.7.5</mod-configuration-client.version>
+    <raml-module-builder.version>33.2.7</raml-module-builder.version>
+    <junit.version>4.13.2</junit.version>
   </properties>
 
   <repositories>
@@ -47,6 +46,14 @@
       <version>${mod-configuration-client.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.4.0</version>
+      <!-- src/main/java/org/folio/dataimport/util/test/GenericHandlerAnswer.java -->
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <version>${vertx.version}</version>
@@ -60,8 +67,8 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
-      <version>2.19.0</version>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>2.32.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/src/test/java/org/folio/dataimport/util/ExceptionHelperTest.java
+++ b/src/test/java/org/folio/dataimport/util/ExceptionHelperTest.java
@@ -1,6 +1,5 @@
 package org.folio.dataimport.util;
 
-import org.apache.http.HttpStatus;
 import org.folio.dataimport.util.exception.ConflictException;
 import org.junit.Test;
 
@@ -20,7 +19,7 @@ public class ExceptionHelperTest {
   public void shouldReturnBadRequestResponse() {
     Response response = ExceptionHelper.mapExceptionToResponse(new BadRequestException("Bad request message"));
     assertNotNull(response);
-    assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatus());
+    assertEquals(400, response.getStatus());
     assertEquals(MediaType.TEXT_PLAIN, response.getMediaType().toString());
     assertEquals("Bad request message", response.getEntity().toString());
   }
@@ -29,7 +28,7 @@ public class ExceptionHelperTest {
   public void shouldReturnNotFoundResponse() {
     Response response = ExceptionHelper.mapExceptionToResponse(new NotFoundException("Not found message"));
     assertNotNull(response);
-    assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatus());
+    assertEquals(404, response.getStatus());
     assertEquals(MediaType.TEXT_PLAIN, response.getMediaType().toString());
     assertEquals("Not found message", response.getEntity().toString());
   }
@@ -38,7 +37,7 @@ public class ExceptionHelperTest {
   public void shouldReturnConflictResponse() {
     Response response = ExceptionHelper.mapExceptionToResponse(new ConflictException("Conflict message"));
     assertNotNull(response);
-    assertEquals(HttpStatus.SC_CONFLICT, response.getStatus());
+    assertEquals(409, response.getStatus());
     assertEquals(MediaType.TEXT_PLAIN, response.getMediaType().toString());
     assertEquals("Conflict message", response.getEntity().toString());
   }
@@ -47,7 +46,7 @@ public class ExceptionHelperTest {
   public void shouldReturnInternalServerErrorResponse() {
     Response response = ExceptionHelper.mapExceptionToResponse(new InternalServerErrorException("Internal server error message"));
     assertNotNull(response);
-    assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatus());
+    assertEquals(500, response.getStatus());
     assertEquals(MediaType.TEXT_PLAIN, response.getMediaType().toString());
     assertTrue(response.getEntity().toString().contains("Internal Server Error"));
   }


### PR DESCRIPTION
Update dependencies fixing multiple vulnerabilities:

Update RMB from 32.1.0 to 33.2.7.
The RMB update indirectly updates log4j from 2.13.3 to 2.17.1 fixing  https://nvd.nist.gov/vuln/detail/CVE-2021-44228
The RMB update indirectly updates jackson-databind from 2.11.3 to 2.13.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518

Update Vert.x from 4.0.0 to 4.2.6.

Update mod-configuration-client from 5.6.0 to 5.7.5.

Suppress mockito-core from runtime by setting <scope>provided</scope>.