### PR TITLE
MODDICORE-398: Upgrade data-import-utils to RMB 35.2.0, Vert.x 4.5.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildMvn {
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.12.0 2024-03-11
+* [MODDICORE-398](https://issues.folio.org/browse/MODDICORE-398) Upgrade data-import-utils to RMB 35.2.0, Vert.x 4.5.4
+
 ## 1.11.0 2023-03-02
 * [MODDATAIMP-785](https://issues.folio.org/browse/MODDATAIMP-785) Upgrade data-import-utils to RMB 35.0.6, Vert.x 4.3.8, config-client 5.9.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 1.12.0 2024-03-11
-* [MODDICORE-398](https://issues.folio.org/browse/MODDICORE-398) Upgrade data-import-utils to RMB 35.2.0, Vert.x 4.5.4
+* [MODDICORE-398](https://issues.folio.org/browse/MODDICORE-398) Upgrade data-import-utils to jdk 17, RMB 35.2.0, Vert.x 4.5.4
 
 ## 1.11.0 2023-03-02
 * [MODDATAIMP-785](https://issues.folio.org/browse/MODDATAIMP-785) Upgrade data-import-utils to RMB 35.0.6, Vert.x 4.3.8, config-client 5.9.1

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
+          <encoding>UTF-8</encoding>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -127,7 +127,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.5</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
@@ -136,7 +136,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
+        <version>3.5.2</version>
         <configuration>
           <filters>
             <filter>
@@ -163,7 +163,7 @@
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -192,7 +192,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>3.0.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
-      <version>2.35.0</version>
+      <version>3.0.1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.3.8</vertx.version>
+    <vertx.version>4.5.4</vertx.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>
-    <raml-module-builder.version>35.0.6</raml-module-builder.version>
+    <raml-module-builder.version>35.2.0</raml-module-builder.version>
     <junit.version>4.13.2</junit.version>
   </properties>
 


### PR DESCRIPTION
## Purpose
RMB v35.2.x update

## Approach
Upgrade data-import-utils to RMB 35.2.0, Vert.x 4.5.4

## Learning
[MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398)