### PR TITLE
MODDATAIMP-1175: Update to Java 21 data-import-utils library Sunflower R1 2025.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildMvn {
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java17'
+  buildNode = 'jenkins-agent-java21'
 }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-## 1.XX.X 2024-XX-XX
+## 1.14.0-SNAPSHOT 2025-XX-XX
 * [MODSOURCE-821](https://folio-org.atlassian.net/browse/MODSOURCE-821) Add do request by System User for Eureka env
 * [MODDATAIMP-1125](https://folio-org.atlassian.net/browse/MODDATAIMP-1125) Remove dependency on mod-configuration
+* [MODDATAIMP-1175](https://folio-org.atlassian.net/browse/MODDATAIMP-1175) Update to Java 21 data-import-utils library Sunflower R1 2025
 
 ## 1.13.0 2024-10-29
 * [MODDATAIMP-1048](https://folio-org.atlassian.net/browse/MODDATAIMP-1048) Increase timeout default value for the requests in the data-import-utils module

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <release>21</release>
           <encoding>UTF-8</encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>4.5.4</vertx.version>
-    <raml-module-builder.version>35.3.0</raml-module-builder.version>
+    <raml-module-builder.version>35.4.0</raml-module-builder.version>
     <junit.version>4.13.2</junit.version>
   </properties>
 
@@ -42,9 +42,15 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.1.1</version>
+      <version>5.2.0</version>
       <!-- src/main/java/org/folio/dataimport/util/test/GenericHandlerAnswer.java -->
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>1.17.1</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -112,7 +118,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>17</release>
+          <release>21</release>
           <encoding>UTF-8</encoding>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>


### PR DESCRIPTION
Migrate to Java 21.